### PR TITLE
stringify: speed improved by get rid of `buf.join`

### DIFF
--- a/lib/bem-naming.js
+++ b/lib/bem-naming.js
@@ -159,25 +159,25 @@ BEMNaming.prototype.stringify = function (obj) {
         throw new Error('The field `block` is undefined. It is impossible to stringify BEM notation.');
     }
 
-    var buf = [obj.block];
+    var res = obj.block;
 
     if (obj.elem) {
-        buf.push(this.elemDelim + obj.elem);
+        res += this.elemDelim + obj.elem;
     }
 
     if (obj.modName) {
         var modVal = obj.modVal;
 
         if (modVal || modVal === 0 || !obj.hasOwnProperty('modVal')) {
-            buf.push(this.modDelim + obj.modName);
+            res += this.modDelim + obj.modName;
         }
 
         if (modVal && modVal !== true) {
-            buf.push(this.modDelim + modVal);
+            res += this.modDelim + modVal;
         }
     }
 
-    return buf.join('');
+    return res;
 };
 
 BEMNaming.prototype._buildRegex = function () {


### PR DESCRIPTION
**2,5 times faster**

before:

```console
       21,063,721 op/s » block
       6,332,712 op/s » blockMod
       7,619,885 op/s » elem
       5,505,372 op/s » elemMod
```

after: 

```console
      38,288,200 op/s » block
      16,804,498 op/s » blockMod
      21,390,626 op/s » elem
      12,310,409 op/s » elemMod
```