### PR TITLE
parse: speed improved

### DIFF
--- a/lib/bem-naming.js
+++ b/lib/bem-naming.js
@@ -131,19 +131,20 @@ BEMNaming.prototype.parse = function (str) {
 
     if (!executed) return;
 
-    var elem = executed[5],
-        modName = executed[2] || executed[6],
-        modVal = executed[3] || executed[7],
-        notation = {};
+    var notation = {
+            block: executed[1] || executed[4]
+        },
+        elem = executed[5],
+        modName = executed[2] || executed[6];
 
-    if (modName && (modVal === undefined)) {
-        modVal = true;
-    }
-
-    notation.block = executed[1] || executed[4];
     elem && (notation.elem = elem);
-    modName && (notation.modName = modName);
-    modVal && (notation.modVal = modVal);
+
+    if (modName) {
+        var modVal = executed[3] || executed[7];
+
+        notation.modName = modName;
+        notation.modVal = modVal || true;
+    }
 
     return notation;
 };
@@ -184,9 +185,10 @@ BEMNaming.prototype._buildRegex = function () {
     var word = this._wordPattern,
         block = '(' + word + ')',
         elem = '(?:' + this.elemDelim + '(' + word + '))?',
-        mod = '(?:' + this.modDelim + '(' + word + '))?';
+        modPart = '(?:' + this.modDelim + '(' + word + '))?',
+        mod = modPart + modPart;
 
-    this._regex = new RegExp(['^', block, mod, mod, '$|^', block, elem, mod, mod, '$'].join(''));
+    this._regex = new RegExp('^' + block + mod + '$|^' + block + elem + mod + '$');
 };
 
 var defineAsGlobal = true,


### PR DESCRIPTION
**faster by 15%**

before:

```console
       4,644,092 op/s » block
       3,235,655 op/s » blockMod
       3,221,562 op/s » elem
       2,210,935 op/s » elemMod
```

after:

```console
       6,485,415 op/s » block
       3,358,493 op/s » blockMod
       3,366,913 op/s » elem
       2,505,998 op/s » elemMod
```