### PR TITLE
fix(namespace): should return namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,6 +195,11 @@ BEMNaming.prototype._buildRegex = function () {
 
 var defineAsGlobal = true,
     cache = {},
+    methods = [
+        'validate', 'typeOf',
+        'parse', 'stringify',
+        'isBlock', 'isElem', 'isBlockMod', 'isElemMod'
+    ],
     bemNaming = function (options) {
         options || (options = {});
 
@@ -206,19 +211,26 @@ var defineAsGlobal = true,
             },
             id = JSON.stringify(naming);
 
-        return cache[id] || (cache[id] = new BEMNaming(naming));
+        if (cache[id]) {
+            return cache[id];
+        }
+
+        var instance = new BEMNaming(naming),
+            namespace = {};
+
+        methods.forEach(function (method) {
+            namespace[method] = instance[method].bind(instance);
+        });
+        cache[id] = namespace;
+
+        return namespace;
     },
     originalNaming = bemNaming();
 
-bemNaming.BEMNaming  = BEMNaming;
-bemNaming.validate   = function () { return originalNaming.validate.apply(originalNaming, arguments);   };
-bemNaming.parse      = function () { return originalNaming.parse.apply(originalNaming, arguments);      };
-bemNaming.stringify  = function () { return originalNaming.stringify.apply(originalNaming, arguments);  };
-bemNaming.typeOf     = function () { return originalNaming.typeOf.apply(originalNaming, arguments);     };
-bemNaming.isBlock    = function () { return originalNaming.isBlock.apply(originalNaming, arguments);    };
-bemNaming.isElem     = function () { return originalNaming.isElem.apply(originalNaming, arguments);     };
-bemNaming.isBlockMod = function () { return originalNaming.isBlockMod.apply(originalNaming, arguments); };
-bemNaming.isElemMod  = function () { return originalNaming.isElemMod.apply(originalNaming, arguments);  };
+bemNaming.BEMNaming = BEMNaming;
+methods.forEach(function (method) {
+    bemNaming[method] = originalNaming[method];
+});
 
 // Node.js
 /* istanbul ignore if */

--- a/test/namespace.test.js
+++ b/test/namespace.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const test = require('ava');
+const bemNaming = require('../index');
+
+test('should be a namespace', t => {
+    const entities = ['block__elem'].map(bemNaming.parse);
+
+    t.same(entities, [{ block: 'block', elem: 'elem' }]);
+});
+
+test('should be a original namespace', t => {
+    const myNaming = bemNaming();
+    const entities = ['block__elem'].map(myNaming.parse);
+
+    t.same(entities, [{ block: 'block', elem: 'elem' }]);
+});
+
+test('should be a custom namespace', t => {
+    const myNaming = bemNaming({ elem: '==' });
+    const entities = ['block==elem'].map(myNaming.parse);
+
+    t.same(entities, [{ block: 'block', elem: 'elem' }]);
+});


### PR DESCRIPTION
Resolved #66

The `bemNaming` function should return namespace instead of instance of BEMNaming.

It is necessary to work with Array methods:

```js
import bemNaming from 'bem-naming';

const myNaming = bemNaming({ mod: '--' });

['block__elem', 'block--mod'].map(myNaming.parse);
```