### PR TITLE
fix(options): remove deprecated options

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,10 +204,9 @@ var defineAsGlobal = true,
         options || (options = {});
 
         var naming = {
-                elem: options.elem || options.elemSeparator || '__',
-                mod: options.mod || options.modSeparator || '_',
-                wordPattern: options.wordPattern || options.literal && (options.literal + '+') ||
-                    '[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*'
+                elem: options.elem || '__',
+                mod: options.mod || '_',
+                wordPattern: options.wordPattern || '[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*'
             },
             id = JSON.stringify(naming);
 


### PR DESCRIPTION
Resolved #50 

Removed the following options:

* `elemSeparator`
* `modSeparator`
* `literal`

Now need use `elem`, `mod` and `wordPattern` instead.