### PR TITLE
fix(fields): does not delim fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,6 +196,7 @@ var defineAsGlobal = true,
         'parse', 'stringify',
         'isBlock', 'isElem', 'isBlockMod', 'isElemMod'
     ],
+    fields = ['elemDelim', 'modDelim'],
     bemNaming = function (options) {
         options || (options = {});
 
@@ -216,14 +217,17 @@ var defineAsGlobal = true,
         methods.forEach(function (method) {
             namespace[method] = instance[method].bind(instance);
         });
+        fields.forEach(function (field) {
+            namespace[field] = instance[field];
+        });
         cache[id] = namespace;
 
         return namespace;
     },
     originalNaming = bemNaming();
 
-methods.forEach(function (method) {
-    bemNaming[method] = originalNaming[method];
+methods.concat(fields).forEach(function (name) {
+    bemNaming[name] = originalNaming[name];
 });
 
 // Node.js

--- a/test/fields.test.js
+++ b/test/fields.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const test = require('ava');
+const naming = require('../index');
+
+test('should have elemDelim field', t => {
+    t.ok(naming.elemDelim);
+});
+
+test('should have modDelim field', t => {
+    t.ok(naming.modDelim);
+});
+
+test('should create namespace with elemDelim field', t => {
+    const myNaming = naming();
+
+    t.ok(myNaming.elemDelim);
+});
+
+test('should create namespace with modDelim field', t => {
+    const myNaming = naming();
+
+    t.ok(myNaming.modDelim);
+});


### PR DESCRIPTION
Resolved #77 

The default namespace and namespaces with custom naming should includes
`elemDelim` and `modDelim` fields.
